### PR TITLE
Optimize sequencing procedure

### DIFF
--- a/op-service/sources/eth_client.go
+++ b/op-service/sources/eth_client.go
@@ -383,6 +383,19 @@ func (s *EthClient) ReadStorageAt(ctx context.Context, address common.Address, s
 	return common.BytesToHash(value.Bytes()), nil
 }
 
+// GetTransactionByBlockHashAndIndex returns the transaction at the given index in the block with the given hash.
+func (s *EthClient) TxByBlockHashAndIndex(ctx context.Context, blockHash common.Hash, index uint64) (*types.Transaction, error) {
+	var tx *types.Transaction
+	err := s.client.CallContext(ctx, &tx, "eth_getTransactionByBlockHashAndIndex", blockHash.Hex(), hexutil.EncodeUint64(index))
+	if err != nil {
+		return nil, fmt.Errorf("failed to fetch transaction in block %s at index %d: %w", blockHash, index, err)
+	}
+	if tx == nil {
+		return nil, ethereum.NotFound
+	}
+	return tx, nil
+}
+
 func (s *EthClient) Close() {
 	s.client.Close()
 }


### PR DESCRIPTION
Currently sequencer needs to `preparePayloadAttributes` before start building the next L2 block. 

https://github.com/megaeth-labs/optimism/blob/ec45f6634ab2855a4ae5d30c4e240d79f081d689/op-node/rollup/sequencing/sequencer.go#L495

However, `preparePayloadAttributes` functions rely on `eth_getBlockByHash` JSON-RPC to fetch the L2 system config by obtaining the sequenced L2 block:

https://github.com/megaeth-labs/optimism/blob/9480fcddb75957bde609a8d658a058b91ec9902e/op-service/sources/l2_client.go#L161

However, L2 block may be too large so that `eth_getBlockByHash` JSON-RPC takes a long time, blocking the process of the sequencer. 
In fact, only the first transaction in the previous L2 block is needed to fetch the L2 system config. 
Therefore, this PR avoids `eth_getBlockByHash` JSON-RPC and use `eth_getTransactionByBlockHashAndIndex` to fetch only the first transaction in the previous L2 block. 
Thus reducing latency in sequencing process. 

This PR relies on https://github.com/megaeth-labs/mega-reth/pull/115

