### PR TITLE
force L1 origin to be finalized L1 block

### DIFF
--- a/op-node/cmd/genesis/systemconfig.go
+++ b/op-node/cmd/genesis/systemconfig.go
@@ -28,7 +28,7 @@ func NewSystemConfigContract(caller *batching.MultiCaller, addr common.Address) 
 }
 
 func (c *SystemConfigContract) StartBlock(ctx context.Context) (*big.Int, error) {
-	result, err := c.caller.SingleCall(ctx, rpcblock.Latest, c.contract.Call(methodStartBlock))
+	result, err := c.caller.SingleCall(ctx, rpcblock.Finalized, c.contract.Call(methodStartBlock))
 	if err != nil {
 		return nil, fmt.Errorf("failed to call startBlock: %w", err)
 	}


### PR DESCRIPTION
mega-reth match branch:  https://github.com/megaeth-labs/mega-reth/tree/clay/feature/l1_origin_finalized

修改位置: 
- 初始化rollup.json, 获取的l1-latest -> l1-finalized
- 修改op-node启动参数,   "--sequencer.enabled", "--sequencer.l1-confs", "10", "--verifier.l1-confs", "10";

对第2点修改的解释:  通过 --sequencer.l1-conf = 10这个值来保证获取的块一定是`finalized`, 换句话说，如果现在l1-latest=100, 那么l2的l1origin最多是90, 那么在第90个块必定是finalized, 生产环境可以设置为64-100(一个块的finalized最长时间是2个epoch = 2 * 32 slot = 2 * 32 * 1 个块时间 = 2 * 32 = 64;

![img_v3_02fm_40c4c699-ca50-4891-862a-f985bbfc777h](https://github.com/user-attachments/assets/05db3e51-cc23-4d68-baba-15ad088ff221)
![img_v3_02fm_6121c023-9fa2-452e-b245-f30cc970cbeh](https://github.com/user-attachments/assets/37489a2e-35f6-4df8-9698-153f4f58842a)


另外一种方法是在findL1origin这个函数里加一个 eth_getBlockByNumber('finalized', false)获取最新`finalized`区块比较;(这个相对保险但感觉没必要）；