### PR TITLE
reduce spike between get_payload and new_payload

### DIFF
--- a/op-node/rollup/engine/events.go
+++ b/op-node/rollup/engine/events.go
@@ -253,7 +253,7 @@ func (d *EngDeriver) OnEvent(ev event.Event) bool {
 			d.ec.SetSafeHead(x.Ref)
 			d.emitter.Emit(SafeDerivedEvent{Safe: x.Ref, DerivedFrom: x.DerivedFrom})
 			// Try to apply the forkchoice changes
-			d.emitter.Emit(TryUpdateEngineEvent{})
+			//d.emitter.Emit(TryUpdateEngineEvent{})
 		}
 	case PromoteFinalizedEvent:
 		if x.Ref.Number < d.ec.Finalized().Number {


### PR DESCRIPTION
As TPS increases, the time-consuming spikes of `interval3_between_get_payload_and_new_payload` in the sequence logic will increase. As shown in the following figure:
<img width="634" alt="image" src="https://github.com/user-attachments/assets/af159c20-29d9-4bce-abdb-a79d2ac704cd">

After debugging， it was found that the `try-update-engine` in the derived logic was executed before the `new_payload` function handler was executed.

The purpose is to reduce the number of `try-update-engine` calls. The `try-update-engine` event is triggered in four places, and the effects of the triggering are the same. Each block generation will trigger the `try-update-engine` event, so directly deleting `try-update-engine` in the derived logic will not have any effect.

The same TPS spikes after modification are as follows:
<img width="630" alt="image" src="https://github.com/user-attachments/assets/a38a0603-7eba-4cca-bc5e-036d56d45ea2">

