### PR TITLE
fix(op-node): Execute only part of the initialReset function each time

### DIFF
--- a/op-node/flags/flags.go
+++ b/op-node/flags/flags.go
@@ -203,6 +203,13 @@ var (
 		}(),
 		Category: RollupCategory,
 	}
+	PipelineInitialResetTimeout = &cli.Uint64Flag{
+		Name:     "l1.pipeline-initial-reset-timeout",
+		Usage:    "Number of L1 blocks to keep distance from the L1 head as a sequencer for picking an L1 origin.",
+		EnvVars:  prefixEnvVars("PIPELINE_INITIAL_RESET_TIMEOUT"),
+		Value:    10,
+		Category: L1RPCCategory,
+	}
 	VerifierL1Confs = &cli.Uint64Flag{
 		Name:     "verifier.l1-confs",
 		Usage:    "Number of L1 blocks to keep distance from the L1 head before deriving L2 data from. Reorgs are supported, but may be slow to perform.",
@@ -419,6 +426,7 @@ var optionalFlags = []cli.Flag{
 	ConductorRpcTimeoutFlag,
 	SafeDBPath,
 	L2EngineKind,
+	PipelineInitialResetTimeout,
 }
 
 var DeprecatedFlags = []cli.Flag{

--- a/op-node/flags/flags.go
+++ b/op-node/flags/flags.go
@@ -205,7 +205,7 @@ var (
 	}
 	PipelineInitialResetTimeout = &cli.Uint64Flag{
 		Name:     "l1.pipeline-initial-reset-timeout",
-		Usage:    "Number of L1 blocks to keep distance from the L1 head as a sequencer for picking an L1 origin.",
+		Usage:    "Number of L1 blocks, control pipeline initial reset.",
 		EnvVars:  prefixEnvVars("PIPELINE_INITIAL_RESET_TIMEOUT"),
 		Value:    10,
 		Category: L1RPCCategory,

--- a/op-node/node/config.go
+++ b/op-node/node/config.go
@@ -74,6 +74,8 @@ type Config struct {
 
 	// AltDA config
 	AltDA altda.CLIConfig
+
+	PipelineInitialResetTimeout uint64
 }
 
 type RPCConfig struct {

--- a/op-node/node/node.go
+++ b/op-node/node/node.go
@@ -425,7 +425,7 @@ func (n *OpNode) initL2(ctx context.Context, cfg *Config) error {
 		n.safeDB = safedb.Disabled
 	}
 	n.l2Driver = driver.NewDriver(n.eventSys, n.eventDrain, &cfg.Driver, &cfg.Rollup, n.l2Source, n.l1Source,
-		n.supervisor, n.beacon, n, n, n.log, n.metrics, cfg.ConfigPersistence, n.safeDB, &cfg.Sync, sequencerConductor, altDA)
+		n.supervisor, n.beacon, n, n, n.log, n.metrics, cfg.ConfigPersistence, n.safeDB, &cfg.Sync, sequencerConductor, altDA, cfg.PipelineInitialResetTimeout)
 	return nil
 }
 

--- a/op-node/rollup/derive/error.go
+++ b/op-node/rollup/derive/error.go
@@ -15,6 +15,8 @@ var (
 	// EngineELSyncing implies that the execution engine is currently in progress of syncing.
 	EngineELSyncing = errors.New("engine is performing EL sync")
 
+	InitialResetting = errors.New("pipeline is performing reset")
+
 	// Sentinel errors, use these to get the severity of errors by calling
 	// errors.Is(err, ErrTemporary) for example.
 	ErrTemporary = NewTemporaryError(nil)

--- a/op-node/rollup/driver/driver.go
+++ b/op-node/rollup/driver/driver.go
@@ -173,6 +173,7 @@ func NewDriver(
 	syncCfg *sync.Config,
 	sequencerConductor conductor.SequencerConductor,
 	altDA AltDAIface,
+	pipelineInitialResetTimeout uint64,
 ) *Driver {
 	driverCtx, driverCancel := context.WithCancel(context.Background())
 
@@ -215,7 +216,7 @@ func NewDriver(
 	sys.Register("attributes-handler",
 		attributes.NewAttributesHandler(log, cfg, driverCtx, l2), opts)
 
-	derivationPipeline := derive.NewDerivationPipeline(log, cfg, verifConfDepth, l1Blobs, altDA, l2, metrics)
+	derivationPipeline := derive.NewDerivationPipeline(log, cfg, verifConfDepth, l1Blobs, altDA, l2, metrics, pipelineInitialResetTimeout)
 
 	sys.Register("pipeline",
 		derive.NewPipelineDeriver(driverCtx, derivationPipeline), opts)

--- a/op-node/service.go
+++ b/op-node/service.go
@@ -75,6 +75,8 @@ func NewConfig(ctx *cli.Context, log log.Logger) (*node.Config, error) {
 		haltOption = ""
 	}
 
+	pipelineInitialResetTimeout := ctx.Uint64(flags.PipelineInitialResetTimeout.Name)
+
 	if ctx.IsSet(flags.HeartbeatEnabledFlag.Name) ||
 		ctx.IsSet(flags.HeartbeatMonikerFlag.Name) ||
 		ctx.IsSet(flags.HeartbeatURLFlag.Name) {
@@ -112,7 +114,8 @@ func NewConfig(ctx *cli.Context, log log.Logger) (*node.Config, error) {
 		ConductorRpc:        ctx.String(flags.ConductorRpcFlag.Name),
 		ConductorRpcTimeout: ctx.Duration(flags.ConductorRpcTimeoutFlag.Name),
 
-		AltDA: altda.ReadCLIConfig(ctx),
+		AltDA:                       altda.ReadCLIConfig(ctx),
+		PipelineInitialResetTimeout: pipelineInitialResetTimeout,
 	}
 
 	if err := cfg.LoadPersisted(log); err != nil {


### PR DESCRIPTION
This pr is for fixing event dead loop when restarting op-node and the unsafe/safe difference is large.

Problem: When the unsafe/safe difference is large, the restart op-node will call `initialReset()`, If this function call takes too long, the `pipelineHandler` will be blocked and unable to consume events in `pipeline queue`(the `executor` keep adding events to `pipeline queue`). The `pipelineHandler` will also generate events when executing the event consumption logic.


