### PR TITLE
feat: Asynchronously commit the full unsafePayload to other nodes and conductor

### DIFF
--- a/op-node/rollup/conductor/conductor_helper.go
+++ b/op-node/rollup/conductor/conductor_helper.go
@@ -1,0 +1,120 @@
+package conductor
+
+import (
+	"context"
+	"time"
+
+	"github.com/ethereum/go-ethereum/log"
+
+	"github.com/ethereum-optimism/optimism/op-node/rollup"
+	"github.com/ethereum-optimism/optimism/op-node/rollup/event"
+	"github.com/ethereum-optimism/optimism/op-service/eth"
+)
+
+// SequencerActionEvent triggers the sequencer to start/seal a block, if active and ready to act.
+// This event is used to prioritize sequencer work over derivation work,
+// by emitting it before e.g. a derivation-pipeline step.
+// A future sequencer in an async world may manage its own execution.
+type CommitPayloadEvent struct {
+	// if payload should be promoted to safe (must also be pending safe, see DerivedFrom)
+	IsLastInSpan bool
+	// payload is promoted to pending-safe if non-zero
+	DerivedFrom eth.L1BlockRef
+
+	Info eth.PayloadInfo
+	Ref  eth.L2BlockRef
+}
+
+func (ev CommitPayloadEvent) String() string {
+	return "commit-payload"
+}
+
+type BuildingState struct {
+	Onto eth.L2BlockRef
+	Info eth.PayloadInfo
+
+	Started time.Time
+
+	// Set once known
+	Ref eth.L2BlockRef
+}
+
+type ExecEngine interface {
+	GetPayload(ctx context.Context, payloadInfo eth.PayloadInfo) (*eth.ExecutionPayloadEnvelope, error)
+	GetBuiltPayload(ctx context.Context, payloadInfo eth.PayloadInfo) (*eth.ExecutionPayloadEnvelope, error)
+}
+
+type AsyncGossiper interface {
+	Gossip(payload *eth.ExecutionPayloadEnvelope)
+	Get() *eth.ExecutionPayloadEnvelope
+	Clear()
+	Stop()
+	Start()
+}
+
+type SequencerClient interface {
+	CommitUnsafePayload(*eth.ExecutionPayloadEnvelope) error
+}
+
+type ConductorHelper struct {
+	ctx context.Context
+
+	engine ExecEngine // Underlying execution engine RPC
+
+	log         log.Logger
+	rollupCfg   *rollup.Config
+	spec        *rollup.ChainSpec
+	sequencer   SequencerClient
+	asyncGossip AsyncGossiper
+
+	emitter event.Emitter
+}
+
+func NewConductorHelper(driverCtx context.Context, engine ExecEngine, log log.Logger, rollupCfg *rollup.Config,
+	sequencer SequencerClient,
+	asyncGossip AsyncGossiper,
+) *ConductorHelper {
+	return &ConductorHelper{
+		ctx:         driverCtx,
+		engine:      engine,
+		log:         log,
+		rollupCfg:   rollupCfg,
+		spec:        rollup.NewChainSpec(rollupCfg),
+		sequencer:   sequencer,
+		asyncGossip: asyncGossip,
+	}
+}
+
+func (d *ConductorHelper) AttachEmitter(em event.Emitter) {
+	d.emitter = em
+}
+
+func (d *ConductorHelper) OnEvent(ev event.Event) bool {
+
+	switch x := ev.(type) {
+	case CommitPayloadEvent:
+		d.onCommitPayload(x)
+
+	default:
+		return false
+	}
+	return true
+}
+
+func (d *ConductorHelper) onCommitPayload(ev CommitPayloadEvent) {
+	const getPayloadTimeout = time.Second * 100
+	ctx, cancel := context.WithTimeout(d.ctx, getPayloadTimeout)
+	defer cancel()
+
+	envelope, err := d.engine.GetPayload(ctx, ev.Info)
+
+	if err != nil {
+		if x, ok := err.(eth.InputError); ok && x.Code == eth.UnknownPayload { //nolint:all
+			d.log.Warn("Cannot seal block, payload ID is unknown",
+				"payloadID", ev.Info.ID, "payload_time", ev.Info.Timestamp)
+		}
+		return
+	}
+	d.asyncGossip.Gossip(envelope)
+	d.sequencer.CommitUnsafePayload(envelope)
+}

--- a/op-node/rollup/driver/driver.go
+++ b/op-node/rollup/driver/driver.go
@@ -249,6 +249,9 @@ func NewDriver(
 		sequencer = sequencing.NewSequencer(driverCtx, log, cfg, attrBuilder, findL1Origin,
 			sequencerStateListener, sequencerConductor, asyncGossiper, metrics)
 		sys.Register("sequencer", sequencer, opts)
+
+		conductorHelper := conductor.NewConductorHelper(driverCtx, l2, log, cfg, sequencer, asyncGossiper)
+		sys.Register("conductor-helper", conductorHelper, opts)
 	} else {
 		sequencer = sequencing.DisabledSequencer{}
 	}

--- a/op-node/rollup/engine/build_seal.go
+++ b/op-node/rollup/engine/build_seal.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"time"
 
+	"github.com/ethereum-optimism/optimism/op-node/rollup/conductor"
 	"github.com/ethereum-optimism/optimism/op-node/rollup/derive"
 	"github.com/ethereum-optimism/optimism/op-service/eth"
 )
@@ -99,6 +100,13 @@ func (eq *EngDeriver) onBuildSeal(ev BuildSealEvent) {
 		})
 		return
 	}
+
+	eq.emitter.Emit(conductor.CommitPayloadEvent{
+		IsLastInSpan: ev.IsLastInSpan,
+		DerivedFrom:  ev.DerivedFrom,
+		Info:         ev.Info,
+		Ref:          ref,
+	})
 
 	now := time.Now()
 	sealTime := now.Sub(sealingStart)

--- a/op-node/rollup/engine/build_seal.go
+++ b/op-node/rollup/engine/build_seal.go
@@ -57,6 +57,12 @@ func (eq *EngDeriver) onBuildSeal(ev BuildSealEvent) {
 	defer cancel()
 
 	sealingStart := time.Now()
+	eq.emitter.Emit(conductor.CommitPayloadEvent{
+		IsLastInSpan: ev.IsLastInSpan,
+		DerivedFrom:  ev.DerivedFrom,
+		Info:         ev.Info,
+		Ref:          eth.L2BlockRef{},
+	})
 	envelope, err := eq.ec.engine.GetMinimizedPayload(ctx, ev.Info)
 	if err != nil {
 		if x, ok := err.(eth.InputError); ok && x.Code == eth.UnknownPayload { //nolint:all
@@ -100,13 +106,6 @@ func (eq *EngDeriver) onBuildSeal(ev BuildSealEvent) {
 		})
 		return
 	}
-
-	eq.emitter.Emit(conductor.CommitPayloadEvent{
-		IsLastInSpan: ev.IsLastInSpan,
-		DerivedFrom:  ev.DerivedFrom,
-		Info:         ev.Info,
-		Ref:          ref,
-	})
 
 	now := time.Now()
 	sealTime := now.Sub(sealingStart)

--- a/op-node/rollup/engine/engine_controller.go
+++ b/op-node/rollup/engine/engine_controller.go
@@ -38,6 +38,7 @@ var ErrNoFCUNeeded = errors.New("no FCU call was needed")
 type ExecEngine interface {
 	GetPayload(ctx context.Context, payloadInfo eth.PayloadInfo) (*eth.ExecutionPayloadEnvelope, error)
 	GetMinimizedPayload(ctx context.Context, payloadInfo eth.PayloadInfo) (*eth.ExecutionPayloadEnvelope, error)
+	GetBuiltPayload(ctx context.Context, payloadInfo eth.PayloadInfo) (*eth.ExecutionPayloadEnvelope, error)
 	ForkchoiceUpdate(ctx context.Context, state *eth.ForkchoiceState, attr *eth.PayloadAttributes) (*eth.ForkchoiceUpdatedResult, error)
 	NewPayload(ctx context.Context, payload *eth.ExecutionPayload, parentBeaconBlockRoot *common.Hash) (*eth.PayloadStatusV1, error)
 	NewPayloadWithPayloadId(ctx context.Context, payloadInfo eth.PayloadInfo, parentBeaconBlockRoot *common.Hash) (*eth.PayloadStatusV1, error)

--- a/op-node/rollup/sequencing/disabled.go
+++ b/op-node/rollup/sequencing/disabled.go
@@ -8,6 +8,7 @@ import (
 	"github.com/ethereum/go-ethereum/common"
 
 	"github.com/ethereum-optimism/optimism/op-node/rollup/event"
+	"github.com/ethereum-optimism/optimism/op-service/eth"
 )
 
 var ErrSequencerNotEnabled = errors.New("sequencer is not enabled")
@@ -47,6 +48,10 @@ func (ds DisabledSequencer) SetMaxSafeLag(ctx context.Context, v uint64) error {
 }
 
 func (ds DisabledSequencer) OverrideLeader(ctx context.Context) error {
+	return ErrSequencerNotEnabled
+}
+
+func (ds DisabledSequencer) CommitUnsafePayload(*eth.ExecutionPayloadEnvelope) error {
 	return ErrSequencerNotEnabled
 }
 

--- a/op-node/rollup/sequencing/iface.go
+++ b/op-node/rollup/sequencing/iface.go
@@ -7,6 +7,7 @@ import (
 	"github.com/ethereum/go-ethereum/common"
 
 	"github.com/ethereum-optimism/optimism/op-node/rollup/event"
+	"github.com/ethereum-optimism/optimism/op-service/eth"
 )
 
 type SequencerIface interface {
@@ -21,5 +22,6 @@ type SequencerIface interface {
 	Stop(ctx context.Context) (hash common.Hash, err error)
 	SetMaxSafeLag(ctx context.Context, v uint64) error
 	OverrideLeader(ctx context.Context) error
+	CommitUnsafePayload(*eth.ExecutionPayloadEnvelope) error
 	Close()
 }

--- a/op-node/rollup/sequencing/sequencer.go
+++ b/op-node/rollup/sequencing/sequencer.go
@@ -293,7 +293,7 @@ func (d *Sequencer) onBuildSealed(x engine.BuildSealedEvent) {
 	// begin gossiping as soon as possible
 	// asyncGossip.Clear() will be called later if an non-temporary error is found,
 	// or if the payload is successfully inserted
-	//d.asyncGossip.Gossip(x.Envelope)
+	// d.asyncGossip.Gossip(x.Envelope)
 	// Now after having gossiped the block, try to put it in our own canonical chain
 	d.emitter.Emit(engine.PayloadProcessEvent{
 		IsLastInSpan: x.IsLastInSpan,
@@ -743,6 +743,15 @@ func (d *Sequencer) SetMaxSafeLag(ctx context.Context, v uint64) error {
 
 func (d *Sequencer) OverrideLeader(ctx context.Context) error {
 	return d.conductor.OverrideLeader(ctx)
+}
+
+func (d *Sequencer) CommitUnsafePayload(Envelope *eth.ExecutionPayloadEnvelope) error {
+	if err := d.conductor.CommitUnsafePayload(d.ctx, Envelope); err != nil {
+		d.emitter.Emit(rollup.EngineTemporaryErrorEvent{
+			Err: fmt.Errorf("failed to commit unsafe payload to conductor: %w", err)})
+		return err
+	}
+	return nil
 }
 
 func (d *Sequencer) Close() {

--- a/op-service/eth/types.go
+++ b/op-service/eth/types.go
@@ -520,6 +520,7 @@ const (
 	NewPayloadV3ById      EngineAPIMethod = "engine_newPayloadV3ById"
 	GetMinimizedPayloadV3 EngineAPIMethod = "engine_getMinimizedPayloadV3"
 
-	GetPayloadV2 EngineAPIMethod = "engine_getPayloadV2"
-	GetPayloadV3 EngineAPIMethod = "engine_getPayloadV3"
+	GetPayloadV2      EngineAPIMethod = "engine_getPayloadV2"
+	GetPayloadV3      EngineAPIMethod = "engine_getPayloadV3"
+	GetBuiltPayloadV3 EngineAPIMethod = "engine_getBuiltPayloadV3"
 )

--- a/op-service/sources/engine_client.go
+++ b/op-service/sources/engine_client.go
@@ -62,7 +62,6 @@ type EngineVersionProvider interface {
 	NewPayloadByIdVersion(timestamp uint64) eth.EngineAPIMethod
 	GetPayloadVersion(timestamp uint64) eth.EngineAPIMethod
 	GetMinimizedPayloadVersion(timestamp uint64) eth.EngineAPIMethod
-	GetBuiltPayloadVersion(timestamp uint64) eth.EngineAPIMethod
 }
 
 func NewEngineAPIClient(rpc client.RPC, l log.Logger, evp EngineVersionProvider) *EngineAPIClient {
@@ -242,7 +241,7 @@ func (s *EngineAPIClient) GetBuiltPayload(ctx context.Context, payloadInfo eth.P
 	e := s.log.New("payload_id", payloadInfo.ID)
 	e.Trace("getting payload")
 	var result eth.ExecutionPayloadEnvelope
-	method := s.evp.GetBuiltPayloadVersion(payloadInfo.Timestamp)
+	method := s.evp.GetPayloadVersion(payloadInfo.Timestamp)
 	err := s.RPC.CallContext(ctx, &result, string(method), payloadInfo.ID)
 	if err != nil {
 		e.Warn("Failed to get payload", "payload_id", payloadInfo.ID, "err", err)

--- a/op-service/sources/engine_client.go
+++ b/op-service/sources/engine_client.go
@@ -62,6 +62,7 @@ type EngineVersionProvider interface {
 	NewPayloadByIdVersion(timestamp uint64) eth.EngineAPIMethod
 	GetPayloadVersion(timestamp uint64) eth.EngineAPIMethod
 	GetMinimizedPayloadVersion(timestamp uint64) eth.EngineAPIMethod
+	GetBuiltPayloadVersion(timestamp uint64) eth.EngineAPIMethod
 }
 
 func NewEngineAPIClient(rpc client.RPC, l log.Logger, evp EngineVersionProvider) *EngineAPIClient {
@@ -234,6 +235,32 @@ func (s *EngineAPIClient) GetMinimizedPayload(ctx context.Context, payloadInfo e
 		return nil, err
 	}
 	e.Trace("Received payload", string(eth.GetMinimizedPayloadV3), *result.ExecutionPayload)
+	return &result, nil
+}
+
+func (s *EngineAPIClient) GetBuiltPayload(ctx context.Context, payloadInfo eth.PayloadInfo) (*eth.ExecutionPayloadEnvelope, error) {
+	e := s.log.New("payload_id", payloadInfo.ID)
+	e.Trace("getting payload")
+	var result eth.ExecutionPayloadEnvelope
+	method := s.evp.GetBuiltPayloadVersion(payloadInfo.Timestamp)
+	err := s.RPC.CallContext(ctx, &result, string(method), payloadInfo.ID)
+	if err != nil {
+		e.Warn("Failed to get payload", "payload_id", payloadInfo.ID, "err", err)
+		if rpcErr, ok := err.(rpc.Error); ok {
+			code := eth.ErrorCode(rpcErr.ErrorCode())
+			switch code {
+			case eth.UnknownPayload:
+				return nil, eth.InputError{
+					Inner: err,
+					Code:  code,
+				}
+			default:
+				return nil, fmt.Errorf("unrecognized rpc error: %w", err)
+			}
+		}
+		return nil, err
+	}
+	e.Trace("Received payload")
 	return &result, nil
 }
 


### PR DESCRIPTION
### Changes:
- Add a new event executor `conductor-helper` to asynchronously commit the full unsafePayload to other nodes and conductor
- Add a new Event `CommitPayloadEvent` to trigger helper commit the full unsafePayload in the original build_seal process.