### PR TITLE
fix: fix command line argument spacing in usage example

### DIFF
--- a/cannon/README.md
+++ b/cannon/README.md
@@ -55,7 +55,7 @@ make cannon
     --l2.claim <L2_CLAIM> \
     --l2.head <L2_HEAD> \
     --l2.blocknumber <L2_BLOCK_NUMBER> \
-    --l2.outputroot <L2_OUTPUT_ROOT>
+    --l2.outputroot <L2_OUTPUT_ROOT> \
     --datadir /tmp/fpp-database \
     --log.format terminal \
     --server


### PR DESCRIPTION
This PR fixes a spacing issue in the command line example provided in the Usage section of the documentation. The `--l2.outputroot <L2_OUTPUT_ROOT>` argument was missing a space at the end, which could cause the command to be parsed incorrectly by the command-line interpreter. Adding a space ensures that the following `--datadir /tmp/fpp-database` parameter is recognized correctly.

Steps taken:
- Located the relevant section in the [document name] file.
- Added a space after `--l2.outputroot <L2_OUTPUT_ROOT>`.