### PR TITLE
feat: try to recover payload building progress when resetting

### DIFF
--- a/op-e2e/actions/helpers/l2_sequencer.go
+++ b/op-e2e/actions/helpers/l2_sequencer.go
@@ -63,7 +63,7 @@ func NewL2Sequencer(t Testing, log log.Logger, l1 derive.L1Fetcher, blobSrc deri
 	seqStateListener := node.DisabledConfigPersistence{}
 	conduc := &conductor.NoOpConductor{}
 	asyncGossip := async.NoOpGossiper{}
-	seq := sequencing.NewSequencer(t.Ctx(), log, cfg, attrBuilder, l1OriginSelector,
+	seq := sequencing.NewSequencer(t.Ctx(), log, cfg, eng, attrBuilder, l1OriginSelector,
 		seqStateListener, conduc, asyncGossip, metr)
 	opts := event.DefaultRegisterOpts()
 	opts.Emitter = event.EmitterOpts{

--- a/op-node/rollup/driver/driver.go
+++ b/op-node/rollup/driver/driver.go
@@ -246,7 +246,7 @@ func NewDriver(
 		attrBuilder := derive.NewFetchingAttributesBuilder(cfg, l1, l2)
 		sequencerConfDepth := confdepth.NewConfDepth(driverCfg.SequencerConfDepth, statusTracker.L1Head, l1)
 		findL1Origin := sequencing.NewL1OriginSelector(log, cfg, sequencerConfDepth)
-		sequencer = sequencing.NewSequencer(driverCtx, log, cfg, attrBuilder, findL1Origin,
+		sequencer = sequencing.NewSequencer(driverCtx, log, cfg, l2, attrBuilder, findL1Origin,
 			sequencerStateListener, sequencerConductor, asyncGossiper, metrics)
 		sys.Register("sequencer", sequencer, opts)
 	} else {

--- a/op-node/rollup/engine/engine_controller.go
+++ b/op-node/rollup/engine/engine_controller.go
@@ -36,12 +36,14 @@ const (
 var ErrNoFCUNeeded = errors.New("no FCU call was needed")
 
 type ExecEngine interface {
+	PayloadBeingBuilt(ctx context.Context) (*eth.PayloadBeingBuiltEnvelope, error)
 	GetPayload(ctx context.Context, payloadInfo eth.PayloadInfo) (*eth.ExecutionPayloadEnvelope, error)
 	GetMinimizedPayload(ctx context.Context, payloadInfo eth.PayloadInfo) (*eth.ExecutionPayloadEnvelope, error)
 	ForkchoiceUpdate(ctx context.Context, state *eth.ForkchoiceState, attr *eth.PayloadAttributes) (*eth.ForkchoiceUpdatedResult, error)
 	NewPayload(ctx context.Context, payload *eth.ExecutionPayload, parentBeaconBlockRoot *common.Hash) (*eth.PayloadStatusV1, error)
 	NewPayloadWithPayloadId(ctx context.Context, payloadInfo eth.PayloadInfo, parentBeaconBlockRoot *common.Hash) (*eth.PayloadStatusV1, error)
 	L2BlockRefByLabel(ctx context.Context, label eth.BlockLabel) (eth.L2BlockRef, error)
+	L2BlockRefByHash(ctx context.Context, hash common.Hash) (eth.L2BlockRef, error)
 }
 
 type EngineController struct {

--- a/op-node/rollup/sequencing/sequencer_test.go
+++ b/op-node/rollup/sequencing/sequencer_test.go
@@ -610,6 +610,7 @@ func TestSequencerBuild(t *testing.T) {
 
 type sequencerTestDeps struct {
 	cfg              *rollup.Config
+	engine           engine.ExecEngine
 	attribBuilder    *FakeAttributesBuilder
 	l1OriginSelector *FakeL1OriginSelector
 	seqState         *BasicSequencerStateListener
@@ -652,7 +653,7 @@ func createSequencer(log log.Logger) (*Sequencer, *sequencerTestDeps) {
 		conductor:   &FakeConductor{},
 		asyncGossip: &FakeAsyncGossip{},
 	}
-	seq := NewSequencer(context.Background(), log, cfg, deps.attribBuilder,
+	seq := NewSequencer(context.Background(), log, cfg, deps.engine, deps.attribBuilder,
 		deps.l1OriginSelector, deps.seqState, deps.conductor,
 		deps.asyncGossip, metrics.NoopMetrics)
 	// We create mock payloads, with the epoch-id as tx[0], rather than proper L1Block-info deposit tx.

--- a/op-service/eth/types.go
+++ b/op-service/eth/types.go
@@ -169,6 +169,12 @@ type (
 	}
 )
 
+type PayloadBeingBuiltEnvelope struct {
+	PayloadID       PayloadID   `json:"id"`
+	Timestamp       uint64      `json:"timestamp"`
+	ParentBlockHash common.Hash `json:"parent"`
+}
+
 type ExecutionPayloadEnvelope struct {
 	ParentBeaconBlockRoot *common.Hash      `json:"parentBeaconBlockRoot,omitempty"`
 	ExecutionPayload      *ExecutionPayload `json:"executionPayload"`

--- a/op-service/sources/engine_client.go
+++ b/op-service/sources/engine_client.go
@@ -245,3 +245,11 @@ func (s *EngineAPIClient) SignalSuperchainV1(ctx context.Context, recommended, r
 	})
 	return result, err
 }
+
+// PayloadBeingBuilt returns the current payload being built by the engine.
+// This is used to check if the sequencer needs to recover the payload being built.
+func (s *EngineAPIClient) PayloadBeingBuilt(ctx context.Context) (*eth.PayloadBeingBuiltEnvelope, error) {
+	var result *eth.PayloadBeingBuiltEnvelope
+	err := s.RPC.CallContext(ctx, &result, "engine_payloadBeingBuilt")
+	return result, err
+}


### PR DESCRIPTION
To my understanding, when op-node starts, it will force resetting the pipeline. 
This PR adds logics to check whether there is payload being built in EL and finish it when resetting is done.
In this way, when op-node restarts, it no longer aborts the incomplete payload in EL.